### PR TITLE
Add additional supervisorctl commands as actions

### DIFF
--- a/resources/config.rb
+++ b/resources/config.rb
@@ -71,6 +71,6 @@ action :create do
     group 'root'
     mode '644'
     variables config: new_resource
-    notifies :reload, find_resource(:supervisor_service, 'supervisor'), :delayed
+    notifies :reread, find_resource(:supervisor_service, 'supervisor'), :delayed
   end
 end

--- a/resources/group.rb
+++ b/resources/group.rb
@@ -15,7 +15,7 @@ action :create do
     group 'root'
     mode '644'
     variables group: new_resource
-    notifies :reload, find_resource(:supervisor_service, 'supervisor'), :delayed
+    notifies :reread, find_resource(:supervisor_service, 'supervisor'), :delayed
   end
 end
 
@@ -23,6 +23,6 @@ action :delete do
   file 'delete specific group configuration file' do
     path(lazy { "#{node.run_state['supervisor']['directory']}/group_#{new_resource.group_name}.conf" })
     action :delete
-    notifies :reload, find_resource(:supervisor_service, 'supervisor'), :delayed
+    notifies :reread, find_resource(:supervisor_service, 'supervisor'), :delayed
   end
 end

--- a/resources/process.rb
+++ b/resources/process.rb
@@ -74,3 +74,14 @@ action :delete do
     notifies :reload, find_resource(:supervisor_service, 'supervisor'), :delayed
   end
 end
+
+action :restart do
+  clean_name = new_resource.defined_process_name.downcase.tr(' ', '_')
+  unique_name_for_process = "#{new_resource.type}_#{clean_name}"
+  supervisor_svc = find_resource(:supervisor_service, 'supervisor')
+  declare_resource(:execute, "supervisorctl_restart_#{unique_name_for_process}") do
+    command(lazy { "#{supervisor_svc.supervisord_executable_path}/supervisorctl -c #{node.run_state['supervisor']['config_file']} restart #{new_resource.defined_process_name}" })
+    action :run
+    only_if "#{supervisor_svc.supervisord_executable_path}/supervisorctl -c #{node.run_state['supervisor']['config_file']} avail"
+  end
+end

--- a/resources/process.rb
+++ b/resources/process.rb
@@ -48,8 +48,6 @@ property :fcgi_socket_mode, String, default: '0700'
 property :template, String, default: 'gamegos-supervisor'
 
 action :create do
-  clean_name = new_resource.defined_process_name.downcase.tr(' ', '_')
-  unique_name_for_process = "#{new_resource.type}_#{clean_name}"
   declare_resource(:template, "supervisor_#{unique_name_for_process}") do
     cookbook new_resource.template
     path(lazy { "#{node.run_state['supervisor']['directory']}/#{unique_name_for_process}.conf" })
@@ -66,8 +64,6 @@ action :create do
 end
 
 action :delete do
-  clean_name = new_resource.defined_process_name.downcase.tr(' ', '_')
-  unique_name_for_process = "#{new_resource.type}_#{clean_name}"
   file 'delete specific program configuration file' do
     path(lazy { "#{node.run_state['supervisor']['directory']}/#{unique_name_for_process}.conf" })
     action :delete
@@ -76,12 +72,20 @@ action :delete do
 end
 
 action :restart do
-  clean_name = new_resource.defined_process_name.downcase.tr(' ', '_')
-  unique_name_for_process = "#{new_resource.type}_#{clean_name}"
   supervisor_svc = find_resource(:supervisor_service, 'supervisor')
   declare_resource(:execute, "supervisorctl_restart_#{unique_name_for_process}") do
     command(lazy { "#{supervisor_svc.supervisord_executable_path}/supervisorctl -c #{node.run_state['supervisor']['config_file']} restart #{new_resource.defined_process_name}" })
     action :run
     only_if "#{supervisor_svc.supervisord_executable_path}/supervisorctl -c #{node.run_state['supervisor']['config_file']} avail"
+  end
+end
+
+action_class do
+  def clean_name
+    new_resource.defined_process_name.downcase.tr(' ', '_')
+  end
+
+  def unique_name_for_process
+    "#{new_resource.type}_#{clean_name}"
   end
 end

--- a/resources/process.rb
+++ b/resources/process.rb
@@ -59,7 +59,7 @@ action :create do
       name: clean_name,
       service: new_resource
     )
-    notifies :reread, find_resource(:supervisor_service, 'supervisor'), :delayed
+    notifies :update, find_resource(:supervisor_service, 'supervisor'), :delayed
   end
 end
 
@@ -67,7 +67,7 @@ action :delete do
   file 'delete specific program configuration file' do
     path(lazy { "#{node.run_state['supervisor']['directory']}/#{unique_name_for_process}.conf" })
     action :delete
-    notifies :reread, find_resource(:supervisor_service, 'supervisor'), :delayed
+    notifies :update, find_resource(:supervisor_service, 'supervisor'), :delayed
   end
 end
 

--- a/resources/process.rb
+++ b/resources/process.rb
@@ -59,7 +59,7 @@ action :create do
       name: clean_name,
       service: new_resource
     )
-    notifies :reload, find_resource(:supervisor_service, 'supervisor'), :delayed
+    notifies :reread, find_resource(:supervisor_service, 'supervisor'), :delayed
   end
 end
 
@@ -67,7 +67,7 @@ action :delete do
   file 'delete specific program configuration file' do
     path(lazy { "#{node.run_state['supervisor']['directory']}/#{unique_name_for_process}.conf" })
     action :delete
-    notifies :reload, find_resource(:supervisor_service, 'supervisor'), :delayed
+    notifies :reread, find_resource(:supervisor_service, 'supervisor'), :delayed
   end
 end
 

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -21,3 +21,17 @@ action :reread do
     only_if "#{new_resource.supervisord_executable_path}/supervisorctl -c #{node.run_state['supervisor']['config_file']} avail"
   end
 end
+
+action :update do
+  execute 'supervisorctl update' do
+    command(lazy { "#{new_resource.supervisord_executable_path}/supervisorctl -c #{node.run_state['supervisor']['config_file']} update" })
+    action :run
+    only_if "#{new_resource.supervisord_executable_path}/supervisorctl -c #{node.run_state['supervisor']['config_file']} avail"
+  end
+end
+
+action :shutdown do
+  poise_service 'supervisor' do
+    action :stop
+  end
+end

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -4,34 +4,45 @@ resource_name :supervisor_service
 property :supervisord_executable_path, String, default: lazy { node['supervisor']['supervisord_default_path'] }
 
 action :create do
-  poise_service 'supervisor' do
-    command(lazy { "#{new_resource.supervisord_executable_path}/supervisord -n -c #{node.run_state['supervisor']['config_file']}" })
-  end
+  supervisor('create')
+end
+
+action :stop do
+  supervisor('stop')
 end
 
 action :reload do
-  Chef::Log.warn('The :reload action has been renamed :reread. Please update your cookbook code for the new action')
-  action_reread
-end
-
-action :reread do
-  execute 'supervisorctl reread' do
-    command(lazy { "#{new_resource.supervisord_executable_path}/supervisorctl -c #{node.run_state['supervisor']['config_file']} reread" })
-    action :run
-    only_if "#{new_resource.supervisord_executable_path}/supervisorctl -c #{node.run_state['supervisor']['config_file']} avail"
-  end
+  # update: Reload config and add/remove as necessary
+  supervisorctl('update')
 end
 
 action :update do
-  execute 'supervisorctl update' do
-    command(lazy { "#{new_resource.supervisord_executable_path}/supervisorctl -c #{node.run_state['supervisor']['config_file']} update" })
-    action :run
-    only_if "#{new_resource.supervisord_executable_path}/supervisorctl -c #{node.run_state['supervisor']['config_file']} avail"
-  end
+  action_reload
 end
 
-action :shutdown do
-  poise_service 'supervisor' do
-    action :stop
+action :reread do
+  # reread: Reload the daemon's configuration files
+  supervisorctl('reread')
+end
+
+action :restart do
+  # reload: Restart the remote supervisord.
+  supervisorctl('reload')
+end
+
+action_class do
+  def supervisor(actn)
+    poise_service 'supervisor' do
+      action actn.to_sym
+      command(lazy { "#{new_resource.supervisord_executable_path}/supervisord -n -c #{node.run_state['supervisor']['config_file']}" })
+      stop_signal 'SIGTERM'
+    end
+  end
+
+  def supervisorctl(command)
+    execute "supervisorctl #{command}" do
+      command(lazy { "#{new_resource.supervisord_executable_path}/supervisorctl -c #{node.run_state['supervisor']['config_file']} #{command}" })
+      action :run
+    end
   end
 end

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -10,6 +10,11 @@ action :create do
 end
 
 action :reload do
+  Chef::Log.warn('The :reload action has been renamed :reread. Please update your cookbook code for the new action')
+  action_reread
+end
+
+action :reread do
   execute 'supervisorctl reread' do
     command(lazy { "#{new_resource.supervisord_executable_path}/supervisorctl -c #{node.run_state['supervisor']['config_file']} reread" })
     action :run


### PR DESCRIPTION
I'm working to replace the poise supervisor cookbook with yours.  Needed a couple tweaks to make that happen, but it's looking great so far!

Changes
* `supervisor_process`
  * added restart action
* `supervisor_service`
  * renamed reload action to reread, added alias for reload
  * added update action
  * added shutdown action

Not sure what spec or test updates would be needed for these changes, so I'm happy for guidance on that